### PR TITLE
Don’t require a SSH deploy/private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Don't require a deploy SSH private key in the pillar
+
 ## Version 1.0.6
 
 * Enable jenkins user to be added to other groups

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ jenkins
 =======
 
 jenkins module that:
+ - Adds the upstream Jenkins apt package repo and signing key
  - installs jenkins
  - preconfigures github server key
- - adds ssh deploy key to jenkins user
- - configures git user & email
- - sets up vhost for jenkins
- - pulls in jenkins pkg repo configuration
+ - (optionally) adds ssh deploy key to jenkins user
+ - configures git to have a user & email info
+ - sets up vhost for jenkins using nginx
 
 
 pillar example
@@ -49,11 +49,3 @@ deploy:
 
 
 ```
-
-
-extending jenkins
------------------
-
-Usually you will want your own set of packages pre-installed on jenkins.
-To do so, just overwrite `jenkins/deps.sls` in your main `file_roots` folder.
-See salt docs [file_roots](http://docs.saltstack.com/en/latest/ref/file_server/file_roots.html)

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -1,4 +1,4 @@
-{% from "jenkins/map.jinja" import jenkins with context %}
+{% from "jenkins/map.jinja" import jenkins, deploy with context %}
 include:
   - .repo
   - nginx
@@ -85,8 +85,8 @@ jenkins:
     - require:
       - user: jenkins
 
-
-/srv/jenkins/.ssh/{{ pillar.deploy.ssh.key_type }}:
+{% if "privkey" in deploy.ssh and deploy.ssh.privkey %}
+/srv/jenkins/.ssh/{{ deploy.ssh.key_type }}:
   file.managed:
     - user: jenkins
     - group: jenkins
@@ -95,6 +95,7 @@ jenkins:
     - require:
       - user: jenkins
       - file: /srv/jenkins/.ssh
+{% endif %}
 
 
 ssh_github_jenkins:

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -8,4 +8,12 @@
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('jenkins', {})) %}
+{% set deploy = salt['grains.filter_by']({
+    'Debian': {
+        'ssh': {
+          'key_type': 'id_rsa',
+        },
+    },
+    'default': 'Debian',
+}, merge=salt['pillar.get']('deploy', {})) %}
 


### PR DESCRIPTION
Not every use of jenkins needs to SSH somewhere so make this optional.