### PR TITLE
Don’t let Jenkins store lots of data under /var/run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Don't require a deploy SSH private key in the pillar
+* Change default webroot where Jenkins unpacks the WAR to be under /var/cache,
+  not /var/run. Configurable via the `jenkins:cache_dir` pillar setting
 
 ## Version 1.0.6
 

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -5,6 +5,7 @@
             'name': 'Your humble Jenkins',
         },
         'optional_groups': [],
+        'war_dir': '/var/cache/jenkins/war'
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('jenkins', {})) %}

--- a/jenkins/templates/default/jenkins
+++ b/jenkins/templates/default/jenkins
@@ -1,3 +1,4 @@
+{% from "jenkins/map.jinja" import jenkins with context -%}
 # defaults for jenkins continuous integration server
 
 # pulled in from the init script; makes things easier.
@@ -25,6 +26,8 @@ JENKINS_HOME=/srv/jenkins
 
 # jenkins /run location
 JENKINS_RUN=/var/run/jenkins
+
+JENKINS_WEBROOT="{{ jenkins.war_dir }}"
 
 # set this to false if you don't want Hudson to run by itself
 # in this set up, you are expected to provide a servlet container
@@ -55,4 +58,4 @@ AJP_PORT=-1
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
 # --argumentsRealm.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
-JENKINS_ARGS="--webroot=$JENKINS_RUN/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT --preferredClassLoader=java.net.URLClassLoader"
+JENKINS_ARGS="--webroot=$JENKINS_WEBROOT --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT --preferredClassLoader=java.net.URLClassLoader"

--- a/jenkins/templates/id_rsa
+++ b/jenkins/templates/id_rsa
@@ -1,1 +1,0 @@
-{{pillar['jenkins']['key']['private']}}

--- a/jenkins/templates/id_rsa.pub
+++ b/jenkins/templates/id_rsa.pub
@@ -1,1 +1,0 @@
-{{pillar['jenkins']['key']['public']['enc']}} {{pillar['jenkins']['key']['public']['key']}} {{pillar['jenkins']['key']['public']['comment']}}


### PR DESCRIPTION
/var/run is often a small memory backed partition, on Vagrant images for
instance this is only 50meg and jenkins tries to unpack the war file into
it and runs out of space.