### PR TITLE
Missing 'with context' in use of map.jinja

### DIFF
--- a/jenkins/templates/default/jenkins-proxy.conf
+++ b/jenkins/templates/default/jenkins-proxy.conf
@@ -1,4 +1,4 @@
-{% from 'jenkins/map.jinja' import jenkins %}
+{% from 'jenkins/map.jinja' import jenkins with context %}
 upstream jenkins {
     server "{{ jenkins.nginx.upstream }}";
 }


### PR DESCRIPTION
This, bizarrely, resulted in a 'variable not found' error when
trying to access `salt['grains.filter_by']()'