### PR TITLE
Add jobs.sls that manages jenkins jobs from a different git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add plugins.sls so you can specify plugins to install in the pillar.
 * Add safe restart on plugin install/change
+* Add jobs.sls so you can manage jenkins jobs via salt
 
 ## Version 1.1.1
 

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -1,0 +1,47 @@
+{% from "jenkins/map.jinja" import jenkins, deploy with context %}
+
+#
+# Check if there's any change in the jobs folder on a file that's tracked.
+# If there is, then call revert-all, which does a checkout
+#
+check-modifications:
+  cmd.run:
+    - user: jenkins
+    - name: git diff --exit-code --quiet || echo changed=true
+    - cwd: /srv/jenkins/jobs/
+    - stateful: True
+    - watch_in:
+      - cmd: revert-all
+
+#
+# Revert all changes by doing a checkout. It will only touch files (jobs)
+# it knows about.
+#
+revert-all:
+  cmd.wait:
+    - user: jenkins
+    - name: git checkout .
+    - cwd: /srv/jenkins/jobs/
+    - watch_in:
+      - cmd: jenkins-safe-restart
+
+#
+# Get all the jobs from the jobs repo and put them into jenkins' jobs folder.
+# Call the safe-reload only if something's changed
+#
+{% if jenkins.jobs.repo_location %}
+{{ jenkins.jobs.repo_location }}:
+  git.latest:
+    - force: True
+    - depth: 10
+    - force_reset: True
+    - force_checkout: True
+    - rev: master
+    - target: /srv/jenkins/jobs/
+    - always_fetch: True
+    - makedirs: True
+    - runas: jenkins
+    - user: jenkins
+    - watch_in:
+      - cmd: jenkins-safe-restart
+{% endif %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -1,6 +1,9 @@
 {% set jenkins = salt['grains.filter_by']({
     'Debian': {
         'plugins': [],
+        'jobs': {
+            'repo_location': '',
+        },
         'nginx' : {
             'upstream': 'localhost:8877',
             'listen': '80',


### PR DESCRIPTION
sls that checks out an external repo containing jenkins jobs, installs them in the jobs directory, after which it safely restarts jenkins. It will only manage jobs it knows about, and it'll always rewrite them if they've changed. In other words, it enforces the state that's in git.