### PR TITLE
Get system user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add plugins.sls so you can specify plugins to install in the pillar.
 * Add safe restart on plugin install/change
 * Add jobs.sls so you can manage jenkins jobs via salt
+* Add sysuser sls to cache the token for jenkins's SYSTEM user
 
 ## Version 1.1.1
 

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -20,7 +20,7 @@ check-modifications:
 revert-all:
   cmd.wait:
     - user: jenkins
-    - name: git checkout .
+    - name: git reset --hard origin/master
     - cwd: /srv/jenkins/jobs/
     - watch_in:
       - cmd: jenkins-safe-restart

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -1,11 +1,14 @@
 {% from "jenkins/map.jinja" import jenkins with context %}
 
+{# test if jenkins_system_user_token grain exists and set it to None if it doesn't #}
+{% set jenkins_system_user_token = salt['grains.get']('jenkins_system_user_token', None) %}
+
 {% for plugin in jenkins.plugins %}
 {{plugin}}:
   jenkins.plugin_installed:
     - name: {{plugin}}
-{% if salt['grains.get']('jenkins_system_user_token', None) != None %}
-    - jenkins_url: "http://SYSTEM:{{ grains['jenkins_system_user_token'] }}@localhost:8877"
+{% if jenkins_system_user_token != None %}
+    - jenkins_url: "http://SYSTEM:{{jenkins_system_user_token}}@localhost:8877"
 {% endif %}
     - require:
       - cmd: /srv/jenkins/update-available-plugins.sh
@@ -13,11 +16,16 @@
     - watch_in:
       - cmd: jenkins-safe-restart
 {% endfor %}
+
 curl:
   pkg.installed
 
 jenkins-safe-restart:
   cmd.wait:
-    - name: curl -X POST http://{{jenkins.nginx.upstream}}/safeRestart
+{% if jenkins_system_user_token != None %}
+    - name: curl -X POST "http://SYSTEM:{{jenkins_system_user_token}}@{{jenkins.nginx.upstream}}/safeRestart"
+{% else %}
+    - name: curl -X POST "http://{{jenkins.nginx.upstream}}/safeRestart"
+{% endif %}
     - require:
       - pkg: curl

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -4,6 +4,9 @@
 {{plugin}}:
   jenkins.plugin_installed:
     - name: {{plugin}}
+{% if salt['grains.get']('jenkins_system_user_token', None) != None %}
+    - jenkins_url: "http://SYSTEM:{{ grains['jenkins_system_user_token'] }}@localhost:8877"
+{% endif %}
     - require:
       - cmd: /srv/jenkins/update-available-plugins.sh
       - service: jenkins

--- a/jenkins/sysuser.sls
+++ b/jenkins/sysuser.sls
@@ -6,12 +6,8 @@ BeautifulSoup:
     - require:
       - pkg: python-pip
 
-
-execute_custom_grain:
-  cmd.run:
-  - user: jenkins
-  - name: python /srv/salt/_grains/sysuser.py
-  - stateful: True
+jenkins_system_user_api_captured:
+  jenkins.ensure_system_user_apikey_grain:
   - require:
     - service: jenkins
     - pip: BeautifulSoup

--- a/jenkins/sysuser.sls
+++ b/jenkins/sysuser.sls
@@ -1,0 +1,13 @@
+{% from "jenkins/map.jinja" import jenkins, deploy with context %}
+
+python-pip:
+  pkg.installed
+
+
+BeautifulSoup:
+  pip.installed:
+    - version: => 3.2.1
+    - require:
+      - pkg: python-pip
+
+

--- a/jenkins/sysuser.sls
+++ b/jenkins/sysuser.sls
@@ -1,9 +1,5 @@
 {% from "jenkins/map.jinja" import jenkins, deploy with context %}
 
-python-pip:
-  pkg.installed
-
-
 BeautifulSoup:
   pip.installed:
     - version: => 3.2.1
@@ -11,3 +7,11 @@ BeautifulSoup:
       - pkg: python-pip
 
 
+execute_custom_grain:
+  cmd.run:
+  - user: jenkins
+  - name: python /srv/salt/_grains/sysuser.py
+  - stateful: True
+  - require:
+    - service: jenkins
+    - pip: BeautifulSoup

--- a/jenkins/sysuser.sls
+++ b/jenkins/sysuser.sls
@@ -1,5 +1,11 @@
 {% from "jenkins/map.jinja" import jenkins, deploy with context %}
 
+#
+# This sls should be included when calling the jenkins API from the CLI, especially
+# if it has auth enabled. It will try and get the SYSTEM user's token, cache it and
+# make it a grain so it can be used in other sls files.
+#
+
 BeautifulSoup:
   pip.installed:
     - version: => 3.2.1


### PR DESCRIPTION
We need to be able to call the jenkins API even after auth is enabled (for safe restart, configure a new job, install a new plugin). To do that we have two options:
1. use oauth every time we call the jenkins API
2. cache the SYSTEM user's token before auth is enabled, and make it a grain

This PR does option 2, as I think version 1 is a lot more complex