### PR TITLE
Add hipchat plugin config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add jenkins hipchat plugin pillar support
+
 ## Version 1.2.4
 
 * Add modifiable java_args parameter (used for tuning memory usage in jenkins' JVM)

--- a/jenkins/hipchat.sls
+++ b/jenkins/hipchat.sls
@@ -1,0 +1,15 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+{% if jenkins.hipchat %}
+/srv/jenkins/jenkins.plugins.hipchat.HipChatNotifier.xml:
+  file.managed:
+    - user: jenkins
+    - group: jenkins
+    - mode: 644
+    - source: salt://jenkins/templates/jenkins.plugins.hipchat.HipChatNotifier.xml
+    - template: jinja
+    - require:
+      - user: jenkins
+{% else %}
+/srv/jenkins/jenkins.plugins.hipchat.HipChatNotifier.xml:
+  file.absent
+{% endif %}

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -3,3 +3,4 @@ include:
   - .proxy
   - .server
   - .logshipping
+  - .hipchat

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -14,6 +14,7 @@
             'name': 'Your humble Jenkins',
         },
         'optional_groups': [],
+        'hipchat': {},
         'java_args': '-Xmx256m',
         'war_dir': '/var/cache/jenkins/war'
     },

--- a/jenkins/templates/jenkins.plugins.hipchat.HipChatNotifier.xml
+++ b/jenkins/templates/jenkins.plugins.hipchat.HipChatNotifier.xml
@@ -1,0 +1,9 @@
+{% from "jenkins/map.jinja" import jenkins, deploy with context %}
+<?xml version='1.0' encoding='UTF-8'?>
+<jenkins.plugins.hipchat.HipChatNotifier_-DescriptorImpl plugin="hipchat@0.1.9">
+  <server>api.hipchat.com</server>
+  <token>{{jenkins.hipchat.apikey}}</token>
+  <v2Enabled>false</v2Enabled>
+  <room>>{{ jenkins.hipchat.roomname }}</room>
+  <sendAs>{{ jenkins.hipchat.from }}</sendAs>
+</jenkins.plugins.hipchat.HipChatNotifier_-DescriptorImpl>


### PR DESCRIPTION
Enable setting up a default hipchat notification setup for
jobs using pillar data. For example,

jenkins:
  hipchat:
    apikey:   'my-api-key'
    roomname: 'Notification Testing'
    from:     'My Jenkins'