### PR TITLE
Fix how jenkins was depending on python-pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Add jenkins hipchat plugin pillar support
+* Fix installing of python modules (BeautifulSoup) pip package under more
+  recent versions of python-formula
 
 ## Version 1.2.4
 

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -3,7 +3,7 @@ git@github.com:ministryofjustice/supervisor-formula.git==v1.1.0
 git@github.com:ministryofjustice/apparmor-formula.git==v1.0.1
 git@github.com:ministryofjustice/firewall-formula.git==v1.1.2
 git@github.com:ministryofjustice/repos-formula.git==v1.1.1
-git@github.com:ministryofjustice/python-formula.git==v1.0.2
+git@github.com:ministryofjustice/python-formula.git==v1.1.2
 git@github.com:ministryofjustice/redis-formula.git==v1.2.0
 git@github.com:ministryofjustice/rabbitmq-formula.git==v1.2.1
 git@github.com:ministryofjustice/java-formula.git==v1.0.1

--- a/jenkins/sysuser.sls
+++ b/jenkins/sysuser.sls
@@ -6,16 +6,12 @@
 # make it a grain so it can be used in other sls files.
 #
 
-jenkins_pkg_requirements:
-  pkg.installed:
-    - pkgs:
-      - python-pip
+include:
+  - python
 
 BeautifulSoup:
   pip.installed:
     - version: => 3.2.1
-    - require:
-      - pkg: python-pip
 
 jenkins_system_user_api_captured:
   jenkins.ensure_system_user_apikey_grain:


### PR DESCRIPTION
Because of packaging issues we had with pip we don't install python-pip
directly anymore, but including `python` has a require in set up for us.