### PR TITLE
Set the jenkins user GID

### DIFF
--- a/jenkins/user.sls
+++ b/jenkins/user.sls
@@ -4,6 +4,7 @@ jenkins-user:
   user.present:
     - name: jenkins
     - uid: 251
+    - gid: 251
     - system: True
     - home: /srv/jenkins
     - shell: /bin/bash


### PR DESCRIPTION
We set the UID in bc6dfcb.

This should be set automatically (as a consequence of specificying the
UID) but setting both explicitly is good for clarity.
